### PR TITLE
Added unit tests

### DIFF
--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypesTest.java
@@ -24,6 +24,9 @@ import java.util.Set;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.BridgeType;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ThingType;
@@ -40,11 +43,12 @@ public class ThingTypesTest extends JavaOSGiTest {
 
     private LoadedTestBundle loadedTestBundle() throws Exception {
         return new LoadedTestBundle("ThingTypesTest.bundle", bundleContext, this::getService,
-                new StuffAddition().thingTypes(3));
+                new StuffAddition().thingTypes(4));
     }
 
     private ThingTypeProvider thingTypeProvider;
     private ChannelTypeRegistry channelTypeRegistry;
+    private ChannelGroupTypeRegistry channelGroupTypeRegistry;
 
     @Before
     public void setUp() {
@@ -53,6 +57,9 @@ public class ThingTypesTest extends JavaOSGiTest {
 
         channelTypeRegistry = getService(ChannelTypeRegistry.class);
         assertThat(channelTypeRegistry, is(notNullValue()));
+
+        channelGroupTypeRegistry = getService(ChannelGroupTypeRegistry.class);
+        assertThat(channelGroupTypeRegistry, is(notNullValue()));
     }
 
     @Test
@@ -60,6 +67,7 @@ public class ThingTypesTest extends JavaOSGiTest {
         try (final AutoCloseable unused = loadedTestBundle()) {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(null);
 
+            // HUE Bridge
             BridgeType bridgeType = (BridgeType) thingTypes.stream().filter(it -> it.toString().equals("hue:bridge"))
                     .findFirst().get();
             assertThat(bridgeType, is(notNullValue()));
@@ -71,6 +79,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(bridgeType.getProperties().get("vendor"), is("Philips"));
             assertThat(bridgeType.getRepresentationProperty(), is("serialNumber"));
 
+            // HUE Lamp
             ThingType thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp")).findFirst().get();
 
             assertThat(thingType, is(notNullValue()));
@@ -163,11 +172,42 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(state.getOptions().get(0).getValue(), is(equalTo("SOUND")));
             assertThat(state.getOptions().get(0).getLabel(), is(equalTo("My great sound.")));
 
+            // HUE Lamp with group
             thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp-with-group")).findFirst().get();
+            assertThat(thingType, is(notNullValue()));
             assertThat(thingType.getProperties().size(), is(0));
             assertThat(thingType.getCategory(), is(nullValue()));
             assertThat(thingType.isListed(), is(true));
             assertThat(thingType.getExtensibleChannelTypeIds(), containsInAnyOrder("brightness", "alarm"));
+
+            List<ChannelGroupDefinition> channelGroupDefinitions = thingType.getChannelGroupDefinitions();
+            assertThat(channelGroupDefinitions.size(), is(2));
+
+            // Channel Group
+            ChannelGroupDefinition channelGroupDefinition = channelGroupDefinitions.stream()
+                    .filter(it -> it.getId().equals("lampgroup")).findFirst().get();
+            assertThat(channelGroupDefinition, is(notNullValue()));
+            ChannelGroupType channelGroupType = channelGroupTypeRegistry
+                    .getChannelGroupType(channelGroupDefinition.getTypeUID());
+            assertThat(channelGroupType, is(notNullValue()));
+            channelDefinitions = channelGroupType.getChannelDefinitions();
+            assertThat(channelDefinitions.size(), is(3));
+
+            // Channel Group without channels
+            channelGroupDefinition = channelGroupDefinitions.stream()
+                    .filter(it -> it.getId().equals("lampgroup-without-channels")).findFirst().get();
+            assertThat(channelGroupDefinition, is(notNullValue()));
+            channelGroupType = channelGroupTypeRegistry.getChannelGroupType(channelGroupDefinition.getTypeUID());
+            assertThat(channelGroupType, is(notNullValue()));
+            channelDefinitions = channelGroupType.getChannelDefinitions();
+            assertThat(channelDefinitions.size(), is(0));
+
+            // HUE Lamp without channels
+            thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp-without-channels")).findFirst()
+                    .get();
+            assertThat(thingType, is(notNullValue()));
+            channelDefinitions = thingType.getChannelDefinitions();
+            assertThat(channelDefinitions.size(), is(0));
         }
     }
 

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ThingTypesTest.bundle/ESH-INF/thing/thing-types.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ThingTypesTest.bundle/ESH-INF/thing/thing-types.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="hue"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="hue" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
@@ -63,7 +62,7 @@
 		<representation-property>uniqueId</representation-property>
 	</thing-type>
 
-	<!-- HUE Lamp with Group -->
+	<!-- HUE Lamp with group -->
 	<thing-type id="lamp-with-group" extensible="brightness, alarm">
 
 		<label>HUE Lamp</label>
@@ -71,17 +70,34 @@
 
 		<channel-groups>
 			<channel-group id="lampgroup" typeId="lampgroup" />
+			<channel-group id="lampgroup-without-channels" typeId="lampgroup-without-channels" />
 		</channel-groups>
 	</thing-type>
 
+	<!-- HUE Lamp without channels -->
+	<thing-type id="lamp-without-channels" listed="false" extensible="alarm,brightness">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+		</supported-bridge-type-refs>
+
+		<label>HUE Lamp</label>
+		<description>My own great HUE Lamp without channels.</description>
+
+		<category>Lightbulb</category>
+
+		<properties>
+			<property name="key1">value1</property>
+			<property name="key2">value2</property>
+		</properties>
+		<representation-property>uniqueId</representation-property>
+	</thing-type>
 
 	<!-- HUE Lamp Color Channel -->
 	<channel-type id="color">
 		<item-type>ColorItem</item-type>
 		<label>HUE Lamp Color</label>
-		<description>The color channel allows to control the color of the hue
-			lamp. It is also possible to dim values and switch the lamp on and
-			off.
+		<description>The color channel allows to control the color of the hue lamp. It is also possible to dim values and
+			switch the lamp on and off.
 		</description>
 		<tags>
 			<tag>Hue</tag>
@@ -116,8 +132,7 @@
 			<tag>Hue</tag>
 			<tag>AlarmSystem</tag>
 		</tags>
-		<state min="0" max="100.0" step="10.0" pattern="%d Peek"
-			readOnly="true">
+		<state min="0" max="100.0" step="10.0" pattern="%d Peek" readOnly="true">
 			<options>
 				<option value="SOUND">My great sound.</option>
 				<option value="LIGHT" />
@@ -134,6 +149,12 @@
 			<channel id="color_temperature" typeId="color_temperature" />
 			<channel id="alarm" typeId="alarm" />
 		</channels>
+	</channel-group-type>
+
+	<!-- Channel Group without channels -->
+	<channel-group-type id="lampgroup-without-channels" advanced="true">
+		<label>Alarm System</label>
+		<description>The alarm system without channels.</description>
 	</channel-group-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
These integration test will harden the API. Before your fix the test are failing like observed in your binding:

```
15:25:26.782 [ESH-file-processing-1] WARN org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker - The XML document '/ESH-INF/thing/thing-types.xml' in module '@bundleId@0x39' could not be parsed: The node 'channels' is missing!
---- Debugging information ----
class               : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
required-type       : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
converter-type      : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter
path                : /thing-descriptions/channel-group-type[2]
line number         : 158
class[1]            : java.util.ArrayList
converter-type[1]   : com.thoughtworks.xstream.converters.collections.CollectionConverter
class[2]            : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionList
converter-type[2]   : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionConverter
version             : not available
-------------------------------
com.thoughtworks.xstream.converters.ConversionException: The node 'channels' is missing!
---- Debugging information ----
class               : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
required-type       : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
converter-type      : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter
path                : /thing-descriptions/channel-group-type[2]
line number         : 158
class[1]            : java.util.ArrayList
converter-type[1]   : com.thoughtworks.xstream.converters.collections.CollectionConverter
class[2]            : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionList
converter-type[2]   : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionConverter
version             : not available
-------------------------------
	at org.eclipse.smarthome.config.xml.util.NodeIterator.next(NodeIterator.java:117)
	at org.eclipse.smarthome.config.xml.util.NodeIterator.nextList(NodeIterator.java:198)
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter.readChannelTypeDefinitions(ChannelGroupTypeConverter.java:59)
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter.unmarshalType(ChannelGroupTypeConverter.java:72)
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter.unmarshalType(ChannelGroupTypeConverter.java:1)
	at org.eclipse.smarthome.core.thing.xml.internal.AbstractDescriptionTypeConverter.unmarshal(AbstractDescriptionTypeConverter.java:194)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
	at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readItem(AbstractCollectionConverter.java:71)
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.addCurrentElementToCollection(CollectionConverter.java:98)
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.populateCollection(CollectionConverter.java:91)
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.populateCollection(CollectionConverter.java:85)
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.unmarshal(CollectionConverter.java:80)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
	at org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionConverter.unmarshal(ThingDescriptionConverter.java:53)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:134)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1185)
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1169)
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1115)
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1062)
	at org.eclipse.smarthome.config.xml.util.XmlDocumentReader.readFromXML(XmlDocumentReader.java:85)
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.parseDocuments(XmlDocumentBundleTracker.java:411)
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.processBundle(XmlDocumentBundleTracker.java:398)
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.access$6(XmlDocumentBundleTracker.java:393)
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker$2.run(XmlDocumentBundleTracker.java:363)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
TEST thingTypesShouldBeRemoved_whenBundleIsUninstalled(org.eclipse.smarthome.core.thing.xml.test.ThingTypesTest) <<< ERROR: 
Expected: is <4>
     but: was <0>
java.lang.AssertionError: 
Expected: is <4>
     but: was <0>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.eclipse.smarthome.core.thing.xml.test.LoadedTestBundle.lambda$0(LoadedTestBundle.java:105)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:152)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:120)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:73)
	at org.eclipse.smarthome.core.thing.xml.test.LoadedTestBundle.<init>(LoadedTestBundle.java:104)
	at org.eclipse.smarthome.core.thing.xml.test.ThingTypesTest.loadedTestBundle(ThingTypesTest.java:45)
	at org.eclipse.smarthome.core.thing.xml.test.ThingTypesTest.thingTypesShouldBeRemoved_whenBundleIsUninstalled(ThingTypesTest.java:216)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
TEST thingTypesShouldLoad(org.eclipse.smarthome.core.thing.xml.test.ThingTypesTest) <<< ERROR: 
Expected: is <4>
     but: was <0>
java.lang.AssertionError: 
Expected: is <4>
     but: was <0>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.eclipse.smarthome.core.thing.xml.test.LoadedTestBundle.lambda$0(LoadedTestBundle.java:105)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:152)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:120)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:73)
	at org.eclipse.smarthome.core.thing.xml.test.LoadedTestBundle.<init>(LoadedTestBundle.java:104)
	at org.eclipse.smarthome.core.thing.xml.test.ThingTypesTest.loadedTestBundle(ThingTypesTest.java:45)
	at org.eclipse.smarthome.core.thing.xml.test.ThingTypesTest.thingTypesShouldLoad(ThingTypesTest.java:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
```

After your changes they are working like a charm.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>